### PR TITLE
Add multi-URL scraping and markdown export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # PageTextScraper
-Talks as input a URL and a list of words to search for in that URL. If any word is found, it returns the containing paragraph, with the matching word in all caps.
+
+This tool fetches web pages and searches their paragraphs for given words.
+Multiple URLs and words may be supplied. Results are written to a JSON file and
+can optionally be exported as a Markdown document.
+
+## Usage
+
+```bash
+python main.py --urls URL1 URL2 --words word1 word2 \
+    --json-output results.json --markdown-output results.md
+```
+
+The generated JSON maps each URL to the words that were found and the matching
+paragraphs.

--- a/main.py
+++ b/main.py
@@ -1,43 +1,95 @@
-"""Simple paragraph scraper and highlighter."""
+"""Simple paragraph scraper and highlighter.
+
+This script can scrape multiple URLs and search for multiple words in the
+retrieved paragraphs. The results for each URL/word pair are saved to a JSON
+file and can optionally be rendered to a Markdown document.
+"""
 
 import argparse
+import json
 import re
+from pathlib import Path
+
 import requests
 from bs4 import BeautifulSoup
 
 
-def main() -> None:
-    """Retrieve a page and print paragraphs matching given words."""
-    parser = argparse.ArgumentParser(
-        description="Find paragraphs containing the specified words"
-    )
-    parser.add_argument("url", help="URL of the page to scrape")
-    parser.add_argument(
-        "words",
-        nargs="+",
-        help="One or more words to search for in the page",
-    )
-    args = parser.parse_args()
+def _scrape_url(url: str, words: list[str]) -> dict[str, list[str]]:
+    """Return paragraphs from *url* containing any of *words*.
 
-    response = requests.get(args.url)
+    The returned mapping has each searched word as the key and a list of
+    paragraphs containing that word as the value. Words are returned in
+    uppercase for emphasis.
+    """
+    response = requests.get(url)
     response.raise_for_status()
 
     soup = BeautifulSoup(response.text, "html.parser")
-    paragraphs = soup.find_all("p")
+    paragraphs = [p.get_text() for p in soup.find_all("p")]
 
-    # Build regex for any of the search terms (case-insensitive)
-    pattern = re.compile(
-        r"(" + "|".join(re.escape(w) for w in args.words) + r")",
-        re.IGNORECASE,
+    results: dict[str, list[str]] = {}
+    for word in words:
+        pattern = re.compile(rf"({re.escape(word)})", re.IGNORECASE)
+        matches = []
+        for text in paragraphs:
+            if pattern.search(text):
+                matches.append(pattern.sub(lambda m: m.group(0).upper(), text))
+        if matches:
+            results[word] = matches
+    return results
+
+
+def _write_markdown(results: dict[str, dict[str, list[str]]], path: Path) -> None:
+    """Write *results* to *path* formatted as Markdown."""
+    lines = []
+    for url, word_map in results.items():
+        lines.append(f"## {url}")
+        for word, paragraphs in word_map.items():
+            lines.append(f"### {word}")
+            for para in paragraphs:
+                lines.append(f"- {para}")
+        lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    """Retrieve pages and save paragraphs matching given words."""
+    parser = argparse.ArgumentParser(
+        description="Find paragraphs containing the specified words",
     )
+    parser.add_argument(
+        "--urls",
+        nargs="+",
+        required=True,
+        help="One or more URLs of pages to scrape",
+    )
+    parser.add_argument(
+        "--words",
+        nargs="+",
+        required=True,
+        help="Words to search for in the pages",
+    )
+    parser.add_argument(
+        "--json-output",
+        default="results.json",
+        help="Path of the JSON file to write results to",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        help="Optional path of a Markdown file to write formatted results",
+    )
+    args = parser.parse_args()
 
-    for p in paragraphs:
-        text = p.get_text()
-        if pattern.search(text):
-            highlighted = pattern.sub(lambda m: m.group(0).upper(), text)
-            print(highlighted)
+    all_results: dict[str, dict[str, list[str]]] = {}
+    for url in args.urls:
+        all_results[url] = _scrape_url(url, args.words)
+
+    json_path = Path(args.json_output)
+    json_path.write_text(json.dumps(all_results, indent=2, ensure_ascii=False))
+
+    if args.markdown_output:
+        _write_markdown(all_results, Path(args.markdown_output))
 
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- allow passing multiple URLs and search words
- output results to JSON and optionally to Markdown
- document new usage

## Testing
- `python -m py_compile main.py`
- `pip install requests beautifulsoup4 -q` *(fails: network blocked when actually running requests)*

------
https://chatgpt.com/codex/tasks/task_e_685ca1a7a77c832ca870b6f790ded898